### PR TITLE
Write to delta answer corrected in ASP 2.2L solution

### DIFF
--- a/Solutions/ASP 2 - Spark Core/ASP 2.2L - Ingesting Data Lab.py
+++ b/Solutions/ASP 2 - Spark Core/ASP 2.2L - Ingesting Data Lab.py
@@ -130,7 +130,7 @@ print("All test pass")
 
 # ANSWER
 products_output_path = f"{DA.paths.working_dir}/delta/products"
-(products_df
+(products_df3
  .write
  .format("delta")
  .mode("overwrite")


### PR DESCRIPTION
Earlier the previous solution which was shared in GitHub ASP 2.2L solution, it used to generate errors in the notebook. 
<img width="1728" alt="Screenshot 2023-02-21 at 3 37 17 PM" src="https://user-images.githubusercontent.com/11945973/220534194-4851f2df-8799-44dd-9a68-86b504608595.png">

After correcting the typo error, now spark jobs are been able to start, as well as all test cases get passed easily.
<img width="1728" alt="Screenshot 2023-02-21 at 3 37 50 PM" src="https://user-images.githubusercontent.com/11945973/220534200-d4d5d33d-9302-42e3-bc87-2667641561aa.png">
